### PR TITLE
Fixed the use of deprecated List.Remove method in bananas

### DIFF
--- a/bananas/devolonter/matchup/src/gamefield.monkey
+++ b/bananas/devolonter/matchup/src/gamefield.monkey
@@ -231,7 +231,7 @@ Class ActionTimer Extends Timer Implements TimerCompleteListener Abstract
 	End Method
 	
 	Method OnTimerComplete:Void()
-		GameField.Timers.Remove(Self)
+		GameField.Timers.RemoveEach(Self)
 	End Method
 
 End Class

--- a/bananas/hitoro/rockout/imports/block.monkey
+++ b/bananas/hitoro/rockout/imports/block.monkey
@@ -23,7 +23,7 @@ Class Block Extends Sprite
 		GameSession.CurrentLevel.FallingBlocks.AddLast Self
 		Self.parent = GameSession.CurrentLevel.FallingBlocks
 		
-		GameSession.CurrentLevel.Blocks.Remove Self
+		GameSession.CurrentLevel.Blocks.RemoveEach Self
 		
 		If Self.hitby
 			Self.xs = Self.hitby.xs * 0.5
@@ -36,7 +36,7 @@ Class Block Extends Sprite
 	End
 	
 	Method Delete ()
-		parent.Remove Self
+		parent.RemoveEach Self
 	End
 	
 	Method New (img:Image, x:Float, y:Float, xs:Float, ys:Float, xscale:Float, yscale:Float)

--- a/bananas/hitoro/rockout/imports/scorebubble.monkey
+++ b/bananas/hitoro/rockout/imports/scorebubble.monkey
@@ -19,7 +19,7 @@ Class ScoreBubble Extends Sprite
 	End
 
 	Method Delete ()
-		parent.Remove Self
+		parent.RemoveEach Self
 	End
 	
 	Function UpdateAll ()

--- a/bananas/hitoro/rockout/imports/shot.monkey
+++ b/bananas/hitoro/rockout/imports/shot.monkey
@@ -13,7 +13,7 @@ Class Shot Extends Sprite
 	Field inert:Int = True ' Shots start off inert, until they start to fall. Prevents player colliding while shooting...
 	
 	Method Delete ()
-		parent.Remove Self
+		parent.RemoveEach Self
 	End
 	
 	Global ReloadDelay:Int
@@ -92,7 +92,7 @@ Class Shot Extends Sprite
 			Endif
 
 			If s.y > vdh + 64
-				GameSession.CurrentLevel.Shots.Remove s
+				GameSession.CurrentLevel.Shots.RemoveEach s
 			Endif
 					
 		Next


### PR DESCRIPTION
Some examples can not be built because they use deprecated and deleted method Remove of the List class. I replaced Remove with RemoveEach.
