### PR TITLE
Debugger for HTML5 target

### DIFF
--- a/modules/trans/jstranslator.monkey
+++ b/modules/trans/jstranslator.monkey
@@ -269,7 +269,7 @@ Class JsTranslator Extends CTranslator
 		Case "print" Return "print"+Bra( arg0 )
 		Case "error" Return "error"+Bra( arg0 )
 		Case "debuglog" Return "debugLog"+Bra( arg0 )
-		Case "debugstop" Return "debugStop()"
+		Case "debugstop" Return "debugger"
 
 		'string/array methods
 		Case "length" Return texpr+".length"


### PR DESCRIPTION
When browser's debugger encounters a keyword “debugger” it stops the execution and goes to the line where he met this keyword. With browsers development tools you can explore stack and move on it. It works in all modern browsers.

A little more detail can be found here: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Statements/debugger

Yes, I realize that it allows you to debug only the translated code. But I think it's better than just the error with "STOP" text.

The debugger runs only when development tools are opened in browser and debugging takes place.

**Chrome:**
1. Just press F12 key

**Firefox:**
1. Choose Web Developer -> Web Console
2. In the console go to the “Debugger” tab

**IE:**
1. Press F12 key
2. In the console, go to the "Script" tab 
3. Press "Start debugging"

**Opera:**
1. Choose Page -> Developer Tools -> Opera Dragonfly
2. In the console go to the "Scripts" tab 
3. Press the "Reload" button
