### PR TITLE
Fixed overriding scheme and port values for Url

### DIFF
--- a/modules/brl/url.monkey
+++ b/modules/brl/url.monkey
@@ -1,11 +1,10 @@
 
 Class Url
 	Method New(url:String, scheme:String = "", port:Int = 0)
-		Set(url)
-		
-		'now override with passed in variables
 		If scheme.Length _scheme = scheme
 		If port > 0 _port = port
+	
+		Set(url)
 	End
 	
 	Method Set:Void(url:String)

--- a/modules/brl/url.monkey
+++ b/modules/brl/url.monkey
@@ -1,19 +1,28 @@
 
 Class Url
 	Method New(url:String, scheme:String = "", port:Int = 0)
-		If scheme.Length _scheme = scheme
-		If port > 0 _port = port
+		If scheme.Length
+			_defaultScheme = scheme
+		Else
+			_defaultScheme = "http"
+		EndIf
+		
+		If port > 0
+			_defaultPort = port
+		Else
+			_defaultPort = 80
+		EndIf
 	
 		Set(url)
 	End
 	
 	Method Set:Void(url:String)
 		_url = url
-		_scheme = "http"
+		_scheme = _defaultScheme
 		_username = ""
 		_password = ""
 		_domain = ""
-		_port = 80
+		_port = _defaultPort
 		_path = "/"
 		_query = ""
 		_fragment = ""
@@ -177,6 +186,9 @@ Class Url
 	Field _path:String
 	Field _query:String
 	Field _fragment:String
+	
+	Field _defaultScheme:String
+	Field _defaultPort:Int
 End
 
 #rem


### PR DESCRIPTION
Scheme and port values in the url string are overridden by the values which were ​​passed to the constructor. This behavior differs from what was in previous versions. So right now it’s impossible to perform the HttpRequest for port not equal to 80 or scheme not equal to http.

P.S. this is a new fork, so there should be no issues with merging this time
