### PR TITLE
android target: activity result callback

### DIFF
--- a/targets/android/modules/native/androidgame.java
+++ b/targets/android/modules/native/androidgame.java
@@ -15,12 +15,17 @@ import android.opengl.*;
 import javax.microedition.khronos.opengles.GL10;
 import javax.microedition.khronos.egl.EGLConfig;
 
+interface IActivityResultCallback {
+	public void Update(int requestCode, int resultCode, Intent data);
+}
+
 class BBAndroidGame extends BBGame implements GLSurfaceView.Renderer,SensorEventListener{
 
 	static BBAndroidGame _androidGame;
 	
 	Activity _activity;
 	GameView _view;
+	IActivityResultCallback _activityResultCallback;
 	
 	Display _display;
 
@@ -447,6 +452,10 @@ class BBAndroidGame extends BBGame implements GLSurfaceView.Renderer,SensorEvent
 	public GameView GetGameView(){
 		return _view;
 	}
+	
+	public void SetActivityResultCallback( IActivityResultCallback callback) {
+		_activityResultCallback = callback;
+	}
 
 	public Bitmap LoadBitmap( String path ){
 		try{
@@ -675,4 +684,12 @@ class AndroidGame extends Activity{
 		_game.KeyEvent( BBGameEvent.KeyDown,0x1a0 );
 		_game.KeyEvent( BBGameEvent.KeyUp,0x1a0 );
 	}
+	
+	@Override
+	protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+		if (_game._activityResultCallback != null) {
+			_game._activityResultCallback.Update(requestCode, resultCode, data);
+		}
+	}
 }
+


### PR DESCRIPTION
this is to allow the android target to be expanded by custom modules that need onActivityResultCallback() when using Activity Intents. good for cameras, IAP, contact lists, etc.

tested with camera, seems to work ok.

coders still need to modify manifest.xml.
