### PR TITLE
Typo fix in Monkey Documentaion

### DIFF
--- a/docs/monkeydoc/Programming/App config settings.monkeydoc
+++ b/docs/monkeydoc/Programming/App config settings.monkeydoc
@@ -1,4 +1,3 @@
-
 > App config settings
 
 App config settings are settings that affect how a project is built.
@@ -32,7 +31,7 @@ The following app config settings are currently supported, shown with example va
 
 'GLFW settings
 '
-#GLFW_USE_GCC=False
+#GLFW_USE_MINGW=False
 #GLFW_WINDOW_TITLE="Monkey Game"
 #GLFW_WINDOW_WIDTH=640
 #GLFW_WINDOW_HEIGHT=480


### PR DESCRIPTION
The Documentation for App Config Settings has a Typo.
# GLFW_USE_GCC should be #GLFW_USE_MINGW.
