### PR TITLE
Generic *_FILES suffix

### DIFF
--- a/src/transcc/builder.monkey
+++ b/src/transcc/builder.monkey
@@ -104,18 +104,25 @@ Class Builder
 		Local cfgPath:=targetPath+"/CONFIG.MONKEY"
 		If FileType( cfgPath )=FILETYPE_FILE PreProcess cfgPath
 		
-		TEXT_FILES=GetConfigVar( "TEXT_FILES" )
-		IMAGE_FILES=GetConfigVar( "IMAGE_FILES" )
-		SOUND_FILES=GetConfigVar( "SOUND_FILES" )
-		MUSIC_FILES=GetConfigVar( "MUSIC_FILES" )
-		BINARY_FILES=GetConfigVar( "BINARY_FILES" )
-		
-		DATA_FILES=TEXT_FILES
-		If IMAGE_FILES DATA_FILES+="|"+IMAGE_FILES
-		If SOUND_FILES DATA_FILES+="|"+SOUND_FILES
-		If MUSIC_FILES DATA_FILES+="|"+MUSIC_FILES
-		If BINARY_FILES DATA_FILES+="|"+BINARY_FILES
-		DATA_FILES=DATA_FILES.Replace( ";","|" )
+		For Local kv:=EachIn GetConfigVars()
+			If kv.Key.EndsWith( "_FILES" )
+				Local value:=kv.Value.Replace( ";", "|" )
+				
+				Select kv.Key
+					Case "TEXT_FILES"
+						TEXT_FILES=value
+					Case "IMAGE_FILES"
+						IMAGE_FILES=value
+					Case "SOUND_FILES"
+						SOUND_FILES=value
+					Case "MUSIC_FILES"
+						MUSIC_FILES=value
+				End
+			
+				If DATA_FILES.Length()>0 DATA_FILES+="|"
+				DATA_FILES+=value
+			Endif
+		Next
 	
 		Local cd:=CurrentDir
 
@@ -135,7 +142,6 @@ Class Builder
 	Field IMAGE_FILES$
 	Field SOUND_FILES$
 	Field MUSIC_FILES$
-	Field BINARY_FILES$
 	
 	Method Execute:Bool( cmd:String,failHard:Bool=True )
 		Return tcc.Execute( cmd,failHard )

--- a/src/transcc/builders/psm.monkey
+++ b/src/transcc/builders/psm.monkey
@@ -63,7 +63,7 @@ Class PsmBuilder Extends Builder
 				Default
 					Die "Invalid music file type"
 				End
-			Else If MatchPath( r,BINARY_FILES )
+			Else
 				    cont.Push "    <Content Include=~q"+t+"~q>"
 					cont.Push "      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>"
 					cont.Push "    </Content>"

--- a/src/transcc/builders/xna.monkey
+++ b/src/transcc/builders/xna.monkey
@@ -77,7 +77,7 @@ Class XnaBuilder Extends Builder
 				Default
 					Die "Invalid music file type"
 				End
-			Else If MatchPath( r,BINARY_FILES )
+			Else
 					cont.Push "  <ItemGroup>"
 					cont.Push "    <Content Include=~q"+t+"~q>"
 					cont.Push "      <Name>"+f+"</Name>"


### PR DESCRIPTION
This patch allows to use universal “SOMETHING_FILES” config setting for data files. For example, VIDEO_FILES, FONT_FILES, etc. Currently we can use BINARY_FILES for that, but I think it isn’t semantic a little, because images and sounds are also binary files, in some way. What do you think about that?
