### PR TITLE
Fixed a bug with 'ambiguity' when using overloads which conflict due to ...

### DIFF
--- a/modules/trans/decl.monkey
+++ b/modules/trans/decl.monkey
@@ -515,6 +515,8 @@ Public
 		Next
 		
 		Local match:FuncDecl,isexact,err$
+		Local bestChoice:FuncDecl = Null
+		Local highestAccuracy:Int = 0
 
 		For Local func:FuncDecl=Eachin funcs
 '			If Not func.CheckAccess() Continue
@@ -525,6 +527,8 @@ Public
 			
 			Local exact=True
 			Local possible=True
+			
+			Local accuracy:Int
 			
 			For Local i=0 Until argDecls.Length
 
@@ -537,7 +541,24 @@ Public
 					
 					exact=False
 					
-					If Not explicit And exprTy.ExtendsType( declTy ) Continue
+					If Not explicit And exprTy.ExtendsType( declTy )
+						Local exprobjTy:= ObjectType(exprTy)
+						Local declobjTy:= ObjectType(declTy)
+						
+						If exprobjTy And declobjTy
+							If exprobjTy.classDecl And exprobjTy.classDecl.ExtendsClass( declobjTy.classDecl )
+								' By having a higher number here than the one below, objects are valued higher
+								' than other types in cases of ambiguity.
+								accuracy += 2
+							Endif
+						Else
+							' The higher this is, the more we prefer conversion via 'ToBlah'
+							' rather than directly using an object (As usually intended).
+							accuracy += 1
+						Endif
+						
+						Continue
+					Endif
 
 				Else If argDecls[i].init
 				
@@ -546,10 +567,23 @@ Public
 				Endif
 			
 				possible=False
+				
 				Exit
 			Next
 			
 			If Not possible Continue
+			
+			If highestAccuracy <> -1
+				If accuracy > highestAccuracy
+					highestAccuracy = accuracy
+					
+					bestChoice = func
+				Elseif accuracy = highestAccuracy
+					highestAccuracy = -1
+					
+					bestChoice = Null
+				Endif
+			Endif
 			
 			If exact
 				If isexact
@@ -561,8 +595,12 @@ Public
 				Endif
 			Else
 				If Not isexact
-					If match 
-						err="Unable to determine overload to use: "+match.ToString()+" or "+func.ToString()+"."
+					If match
+						If Not bestChoice
+							err="Unable to determine overload to use: "+match.ToString()+" or "+func.ToString()+"."
+						Else
+							match = bestChoice
+						Endif
 					Else
 						match=func
 					Endif


### PR DESCRIPTION
...auto-boxing / conversion. Forum thread: http://www.monkey-x.com/Community/posts.php?topic=8708

Not the best of work-arounds, but it's done the job for every situation I've tested. This change basically just makes 'Trans' choose overloads which explicitly use objects over converting via 'ToBlah'. That being said, I can confirm that 'ToBlah' still works without an issue, however with this, it doesn't take priority (It'll assume you want to use the "most optimal" overload). That being said, explicit use of 'ToBlah' works as you'd expect.
