### PR TITLE
Dll creation support for Trans

### DIFF
--- a/modules/trans/cpptranslator.monkey
+++ b/modules/trans/cpptranslator.monkey
@@ -447,7 +447,17 @@ Class CppTranslator Extends CTranslator
 			args+=TransType( arg.type )
 		Next
 		
-		Local t$=TransType( decl.retType )+" "+decl.munged+Bra( args )
+		Local t:String
+		
+		If decl.IsLibrary() Then
+			'#pragma comment(linker, ~q/EXPORT:SomeFunction=_SomeFunction@@@23mangledstuff#@@@@~q)
+			'Emit "#pragma comment(linker, ~q/EXPORT:" + decl.munged["bb_dll_".Length ..] + "=" + decl.munged + "~q)"
+			Emit "extern ~qC~q {"
+			t = "__declspec(dllexport) " + TransType(decl.retType) + " __stdcall" + " " + decl.munged + Bra(args)
+		Else
+			t = TransType(decl.retType) + " " + decl.munged + Bra(args)
+		EndIf
+		
 		If decl.IsAbstract() t+="=0"
 		
 		Local q$
@@ -458,7 +468,11 @@ Class CppTranslator Extends CTranslator
 			q+="static "
 		Endif
 		
-		Emit q+t+";"
+		Emit q + t + ";"
+		
+		If decl.IsLibrary() Then
+			Emit "}"
+		EndIf
 	End
 	
 	Method EmitFuncDecl( decl:FuncDecl )
@@ -479,7 +493,13 @@ Class CppTranslator Extends CTranslator
 		Local id$=decl.munged
 		If decl.ClassScope() id=decl.ClassScope().munged+"::"+id
 		
-		Emit TransType( decl.retType )+" "+id+Bra( args )+"{"
+		'note: emit the right code for exporting a dll function
+		If decl.IsLibrary() Then
+			Emit "__declspec(dllexport) " + TransType(decl.retType) + " __stdcall" + " " + id + Bra(args) + "{"
+		Else
+			Emit TransType(decl.retType) + " " + id + Bra(args) + "{"
+		EndIf
+		
 		
 		BeginLoop
 		
@@ -681,7 +701,14 @@ Class CppTranslator Extends CTranslator
 	
 	Method TransApp$( app:AppDecl )
 	
-		If Not GetConfigVar( "CPP_GC_MODE" ) SetConfigVar "CPP_GC_MODE","1",Type.boolType
+		'note:GC mode changed for dll creation
+		If Not GetConfigVar("CPP_GC_MODE") Then
+			If GetConfigVar("CPP_BUILD_DLL") Then
+				SetConfigVar "CPP_GC_MODE", "2", Type.intType
+			Else
+				SetConfigVar "CPP_GC_MODE", "1", Type.boolType
+			EndIf
+		EndIf
 		
 		gc_mode=Int( GetConfigVar( "CPP_GC_MODE" ) )
 	

--- a/modules/trans/decl.monkey
+++ b/modules/trans/decl.monkey
@@ -1378,8 +1378,7 @@ Class AppDecl Extends ScopeDecl
 		Endif
 		
 		FinalizeClasses
-		'note:Block deadcode elimination for dll functions
-		ResurrectDllFunctions
+
 	End
 	
 	Method FinalizeClasses()

--- a/modules/trans/decl.monkey
+++ b/modules/trans/decl.monkey
@@ -1378,6 +1378,8 @@ Class AppDecl Extends ScopeDecl
 		Endif
 		
 		FinalizeClasses
+		'note:Block deadcode elimination for dll functions
+		ResurrectDllFunctions
 	End
 	
 	Method FinalizeClasses()

--- a/modules/trans/decl.monkey
+++ b/modules/trans/decl.monkey
@@ -1378,7 +1378,8 @@ Class AppDecl Extends ScopeDecl
 		Endif
 		
 		FinalizeClasses
-
+		'note:Block deadcode elimination for dll functions
+		ResurrectDllFunctions
 	End
 	
 	Method FinalizeClasses()

--- a/modules/trans/parser.monkey
+++ b/modules/trans/parser.monkey
@@ -1342,14 +1342,20 @@ Class Parser
 
 		SetErr
 		
+		'note:Trigger dll construction recognized by cpptranslator
 		If CParse( "method" )
-			attrs|=FUNC_METHOD
-		Else If Not CParse( "function" )
+			attrs |= FUNC_METHOD
+		ElseIf CParse("dllfunction")
+			If GetConfigVar("CPP_BUILD_DLL") <> "1" Then
+				SetConfigVar("CPP_BUILD_DLL", "1", Type.boolType)
+			EndIf
+			attrs |= DECL_LIBRARY
+		Else If Not CParse("function")
 			InternalErr
-		Endif
+		EndIf
 		
 		attrs|=_defattrs
-	
+		
 		Local id$
 		Local ty:Type
 		
@@ -1414,7 +1420,10 @@ Class Parser
 				funcDecl.munged=ParseStringLit()
 				'Array $resize hack! move outta here...
 				If funcDecl.munged="$resize" funcDecl.retType=Type.emptyArrayType
-			Endif
+			EndIf
+		'note:Use RAW name & Prevent function name from being changed by later stages
+		ElseIf attrs & DECL_LIBRARY
+			funcDecl.munged = funcDecl.ident
 		Endif
 		
 		If funcDecl.IsExtern() Or funcDecl.IsAbstract() Return funcDecl
@@ -1427,8 +1436,11 @@ Class Parser
 
 		NextToke
 
+		'note:parse some dllfunctions
 		If attrs & (FUNC_CTOR|FUNC_METHOD)
 			CParse "method"
+		ElseIf attrs & DECL_LIBRARY
+			CParse "dllfunction"
 		Else
 			CParse "function"
 		Endif
@@ -1738,9 +1750,10 @@ Class Parser
 			Case "class"
 				_module.InsertDecl ParseClassDecl( attrs )
 			Case "interface"
-				_module.InsertDecl ParseClassDecl( attrs )
-			Case "function"
-				_module.InsertDecl ParseFuncDecl( attrs )
+				_module.InsertDecl ParseClassDecl(attrs)
+			'note:Change parser so that it recognizes the new keyword
+			Case "function", "dllfunction"
+				_module.InsertDecl ParseFuncDecl(attrs)
 			Default
 				Err "Syntax error - expecting declaration."
 			End Select

--- a/modules/trans/toker.monkey
+++ b/modules/trans/toker.monkey
@@ -35,13 +35,14 @@ Class Toker
 	Method _init()
 		If _keywords Return
 		
+		'note:Introduce a new keyword which is excluded from dead code elimination and triggers dll constrction
 		Const keywords:="void strict "+
 		"public private property "+
 		"bool int float string array object mod continue exit "+
 		"include import module extern "+
 		"new self super eachin true false null not "+
 		"extends abstract final select case default "+
-		"const local global field method function class "+
+		"const local global field method function class dllfunction " +
 		"and or shl shr end if then else elseif endif while wend repeat until forever "+
 		"for to step next return "+
 		"interface implements inline alias try catch throw throwable"

--- a/src/transcc/builders/stdcpp.monkey
+++ b/src/transcc/builders/stdcpp.monkey
@@ -47,7 +47,11 @@ Class StdcppBuilder Extends Builder
 		
 		If tcc.opt_build
 
-			Local out:="main_"+HostOS
+			Local out:= "main_" + HostOS
+			'note:change filename for dlls to default to .dll instead of .exe
+			If GetConfigVar("CPP_BUILD_DLL") Then
+				out += ".dll"
+			EndIf
 			DeleteFile out
 			
 			Local OPTS:="",LIBS:=""
@@ -67,6 +71,11 @@ Class StdcppBuilder Extends Builder
 			Case "release"
 				OPTS+=" -O3 -DNDEBUG"
 			End
+			
+			'note:Introduce additional flags when compiling a dll
+			If GetConfigVar("CPP_BUILD_DLL") Then
+				SetConfigVar("CC_OPTS", GetConfigVar("CC_OPTS") + " -shared -Wl,--add-stdcall-alias ")
+			EndIf
 			
 			Local cc_opts:=GetConfigVar( "CC_OPTS" )
 			If cc_opts OPTS+=" "+cc_opts.Replace( ";"," " )


### PR DESCRIPTION
This patch allows transcc to create dlls using the C++ Tool target.
It introduces the new keyword "dllfunction" which triggers Dll creation when used. dllfunctions are excluded from deadcode elimination and a new flag disguises them from functions. dllfunctions have raw names and are therefore not 'munged' this is necessary to satisfy plugin interfaces for third-party applications. when a dll function is used the corresponding file will be a *.dll instead of an exe.  The GC_MODE automatically changes to Mode 2 when a dllfunction is used. There is one remaining quirk: dllfunctions are still exported to the glfw target even if it makes no sense and could break something. I simply don't know how to check for the corresponding target (very likely easy for you?).

You can find  a small code + dll example here:
http://pharmhaus-software.de/public-domain/Dll_example.zip

It would be nice if you could take a look.

Thank you.
