### PR TITLE
Allow Monkey X to generate code for a different target host

### DIFF
--- a/src/transcc/builder.monkey
+++ b/src/transcc/builder.monkey
@@ -52,7 +52,10 @@ Class Builder
 
 		Print "Parsing..."
 		
-		SetConfigVar "HOST",ENV_HOST
+		Local host:String=tcc.opt_host
+		If host.Length<=0 host = ENV_HOST
+		
+		SetConfigVar "HOST",host
 		SetConfigVar "LANG",ENV_LANG
 		SetConfigVar "TARGET",ENV_TARGET
 		SetConfigVar "CONFIG",ENV_CONFIG

--- a/src/transcc/transcc.monkey
+++ b/src/transcc/transcc.monkey
@@ -146,6 +146,7 @@ Class TransCC
 	Field opt_target:String
 	Field opt_modpath:String
 	Field opt_builddir:String
+	Field opt_host:String
 	
 	'config file
 	Field ANDROID_PATH:String

--- a/src/transcc/transcc.monkey
+++ b/src/transcc/transcc.monkey
@@ -297,6 +297,8 @@ Class TransCC
 					opt_modpath=rhs
 				Case "-builddir"
 					opt_builddir=rhs
+				Case "-host"
+					opt_host = rhs.ToLower()
 				Default
 					Die "Unrecognized command line option: "+arg
 				End


### PR DESCRIPTION
This patch allows Trans to generate code for a different target host.
It is very useful when you just need the C++ source to be compiled on Linux but don't want to go through all the hassle of setting up Monkey X or when you don't have the right permissions (Hosted Solutions) to install Monkey X.
