### PR TITLE
Added ability for html5 target to handle #LIBS

### DIFF
--- a/src/transcc/builders/html5.monkey
+++ b/src/transcc/builders/html5.monkey
@@ -184,7 +184,7 @@ Class Html5Builder Extends Builder
 		header += "<!-- lib imports end -->~n"
 		
 		'process header in container doc
-		containerDoc = ReplaceBlock(containerDoc, "HEAD", scriptTags,"~n<!--")
+		containerDoc = ReplaceBlock(containerDoc, "HEAD", header, "~n<!--")
 		SaveString(containerDoc, "MonkeyGame.html")
 		
 		'modify the main script src

--- a/targets/html5/template/MonkeyGame.html
+++ b/targets/html5/template/MonkeyGame.html
@@ -37,6 +37,8 @@ div.splitter{
 	height: 8px;
 }
 </style>
+<!--${HEAD_BEGIN}-->
+<!--${HEAD_END}-->
 <script>
 
 var CANVAS_RESIZE_MODE=1;	//0=locked, 1=stretch, 2=resize


### PR DESCRIPTION
Added the ability for monkey to handle #LIB in html5 target.

Each #LIB will get added in the head as a html script tag.

If the #LIB starts with http:// or https:// then the string will be blindly placed in the src="" attrib. 

If a file exists for the give #LIB then this is copied into the build folder and the resulting path is put into the src="" attrib.

If the file doesn't exist then the #LIB path is blindly put into src="" attrib and assumed user will manually handle the import.
