### PR TITLE
Added Protected and Internal keywords

### DIFF
--- a/modules/trans/decl.monkey
+++ b/modules/trans/decl.monkey
@@ -85,10 +85,6 @@ Class Decl
 		Return (attrs & DECL_PROTECTED)<>0
 	End
 	
-	Method IsProtectedInternal()
-		Return IsInternal() And IsProtected()
-	End
-	
 	Method IsPublic()
 		Return Not IsPrivate() And Not IsInternal() And Not IsProtected()
 	End
@@ -155,9 +151,7 @@ Class Decl
 	
 	Method AssertAccess()
 		If Not CheckAccess()
-			If IsProtectedInternal()
-				Err ToString() +" is protected and internal."
-			Elseif IsProtected()
+			If IsProtected()
 				Err ToString() +" is protected."
 			Elseif IsInternal()
 				Err ToString() +" is internal."

--- a/modules/trans/parser.monkey
+++ b/modules/trans/parser.monkey
@@ -1522,8 +1522,14 @@ Class Parser
 			Case "private"
 				NextToke
 				decl_attrs|=DECL_PRIVATE
+				decl_attrs&=~DECL_INTERNAL
 			Case "public"
 				NextToke
+				decl_attrs&=~DECL_PRIVATE
+				decl_attrs&=~DECL_INTERNAL
+			Case "internal"
+				NextToke
+				decl_attrs|=DECL_INTERNAL
 				decl_attrs&=~DECL_PRIVATE
 			Case "const","global","field"
 				If (attrs & CLASS_INTERFACE) And _toke<>"const" Err "Interfaces can only contain constants and methods."
@@ -1599,6 +1605,9 @@ Class Parser
 			Case "private"
 				NextToke
 				attrs=DECL_PRIVATE
+			Case "internal"
+				NextToke
+				attrs=DECL_INTERNAL
 			Case "import"
 				NextToke
 				If _tokeType=TOKE_STRINGLIT
@@ -1664,6 +1673,9 @@ Class Parser
 			Case "private"
 				NextToke
 				attrs=DECL_PRIVATE
+			Case "internal"
+				NextToke
+				attrs=DECL_INTERNAL
 			Case "extern"
 				If ENV_SAFEMODE
 					If _app.mainModule=_module

--- a/modules/trans/parser.monkey
+++ b/modules/trans/parser.monkey
@@ -1533,12 +1533,17 @@ Class Parser
 				NextToke
 				decl_attrs|=DECL_INTERNAL
 				decl_attrs&=~DECL_PRIVATE
-				' we can be both internal and protected, so don't reset DECL_PROTECTED
+				decl_attrs&=~DECL_PROTECTED
 			Case "protected"
 				NextToke
 				decl_attrs|=DECL_PROTECTED
 				decl_attrs&=~DECL_PRIVATE
-				' we can be both internal and protected, so don't reset DECL_INTERNAL
+				decl_attrs&=~DECL_INTERNAL
+			Case "protectedinternal"
+				NextToke
+				decl_attrs|=DECL_PROTECTED
+				decl_attrs|=DECL_INTERNAL
+				decl_attrs&=~DECL_PRIVATE
 			Case "const","global","field"
 				If (attrs & CLASS_INTERFACE) And _toke<>"const" Err "Interfaces can only contain constants and methods."
 				classDecl.InsertDecls ParseDecls( _toke,decl_attrs )

--- a/modules/trans/parser.monkey
+++ b/modules/trans/parser.monkey
@@ -1539,11 +1539,6 @@ Class Parser
 				decl_attrs|=DECL_PROTECTED
 				decl_attrs&=~DECL_PRIVATE
 				decl_attrs&=~DECL_INTERNAL
-			Case "protectedinternal"
-				NextToke
-				decl_attrs|=DECL_PROTECTED
-				decl_attrs|=DECL_INTERNAL
-				decl_attrs&=~DECL_PRIVATE
 			Case "const","global","field"
 				If (attrs & CLASS_INTERFACE) And _toke<>"const" Err "Interfaces can only contain constants and methods."
 				classDecl.InsertDecls ParseDecls( _toke,decl_attrs )

--- a/modules/trans/parser.monkey
+++ b/modules/trans/parser.monkey
@@ -1523,14 +1523,22 @@ Class Parser
 				NextToke
 				decl_attrs|=DECL_PRIVATE
 				decl_attrs&=~DECL_INTERNAL
+				decl_attrs&=~DECL_PROTECTED
 			Case "public"
 				NextToke
 				decl_attrs&=~DECL_PRIVATE
 				decl_attrs&=~DECL_INTERNAL
+				decl_attrs&=~DECL_PROTECTED
 			Case "internal"
 				NextToke
 				decl_attrs|=DECL_INTERNAL
 				decl_attrs&=~DECL_PRIVATE
+				' we can be both internal and protected, so don't reset DECL_PROTECTED
+			Case "protected"
+				NextToke
+				decl_attrs|=DECL_PROTECTED
+				decl_attrs&=~DECL_PRIVATE
+				' we can be both internal and protected, so don't reset DECL_INTERNAL
 			Case "const","global","field"
 				If (attrs & CLASS_INTERFACE) And _toke<>"const" Err "Interfaces can only contain constants and methods."
 				classDecl.InsertDecls ParseDecls( _toke,decl_attrs )

--- a/modules/trans/preprocessor.monkey
+++ b/modules/trans/preprocessor.monkey
@@ -87,7 +87,17 @@ Function PreProcess$( path$,mdecl:ModuleDecl=Null )
 						Case "private"
 							attrs=DECL_PRIVATE
 						Case "internal"
-							attrs=DECL_INTERNAL
+							If attrs<>DECL_PROTECTED
+								attrs=DECL_INTERNAL
+							Else
+								attrs|=DECL_INTERNAL
+							End
+						Case "protected"
+							If attrs<>DECL_INTERNAL
+								attrs=DECL_PROTECTED
+							Else
+								attrs|=DECL_PROTECTED
+							End
 						Case "import"
 							While toker.TokeType=TOKE_SPACE
 								toke+=toker.Toke

--- a/modules/trans/preprocessor.monkey
+++ b/modules/trans/preprocessor.monkey
@@ -90,8 +90,6 @@ Function PreProcess$( path$,mdecl:ModuleDecl=Null )
 							attrs=DECL_INTERNAL
 						Case "protected"
 							attrs=DECL_PROTECTED
-						Case "protectedinternal"
-							attrs=DECL_PROTECTED|DECL_INTERNAL
 						Case "import"
 							While toker.TokeType=TOKE_SPACE
 								toke+=toker.Toke

--- a/modules/trans/preprocessor.monkey
+++ b/modules/trans/preprocessor.monkey
@@ -86,6 +86,8 @@ Function PreProcess$( path$,mdecl:ModuleDecl=Null )
 							attrs=0
 						Case "private"
 							attrs=DECL_PRIVATE
+						Case "internal"
+							attrs=DECL_INTERNAL
 						Case "import"
 							While toker.TokeType=TOKE_SPACE
 								toke+=toker.Toke

--- a/modules/trans/preprocessor.monkey
+++ b/modules/trans/preprocessor.monkey
@@ -87,17 +87,11 @@ Function PreProcess$( path$,mdecl:ModuleDecl=Null )
 						Case "private"
 							attrs=DECL_PRIVATE
 						Case "internal"
-							If attrs<>DECL_PROTECTED
-								attrs=DECL_INTERNAL
-							Else
-								attrs|=DECL_INTERNAL
-							End
+							attrs=DECL_INTERNAL
 						Case "protected"
-							If attrs<>DECL_INTERNAL
-								attrs=DECL_PROTECTED
-							Else
-								attrs|=DECL_PROTECTED
-							End
+							attrs=DECL_PROTECTED
+						Case "protectedinternal"
+							attrs=DECL_PROTECTED|DECL_INTERNAL
 						Case "import"
 							While toker.TokeType=TOKE_SPACE
 								toke+=toker.Toke

--- a/modules/trans/toker.monkey
+++ b/modules/trans/toker.monkey
@@ -36,7 +36,7 @@ Class Toker
 		If _keywords Return
 		
 		Const keywords:="void strict "+
-		"public private property internal protected protectedinternal "+
+		"public private property internal protected "+
 		"bool int float string array object mod continue exit "+
 		"include import module extern "+
 		"new self super eachin true false null not "+

--- a/modules/trans/toker.monkey
+++ b/modules/trans/toker.monkey
@@ -36,7 +36,7 @@ Class Toker
 		If _keywords Return
 		
 		Const keywords:="void strict "+
-		"public private property internal "+
+		"public private property internal protected "+
 		"bool int float string array object mod continue exit "+
 		"include import module extern "+
 		"new self super eachin true false null not "+

--- a/modules/trans/toker.monkey
+++ b/modules/trans/toker.monkey
@@ -36,7 +36,7 @@ Class Toker
 		If _keywords Return
 		
 		Const keywords:="void strict "+
-		"public private property "+
+		"public private property internal "+
 		"bool int float string array object mod continue exit "+
 		"include import module extern "+
 		"new self super eachin true false null not "+

--- a/modules/trans/toker.monkey
+++ b/modules/trans/toker.monkey
@@ -36,7 +36,7 @@ Class Toker
 		If _keywords Return
 		
 		Const keywords:="void strict "+
-		"public private property internal protected "+
+		"public private property internal protected protectedinternal "+
 		"bool int float string array object mod continue exit "+
 		"include import module extern "+
 		"new self super eachin true false null not "+


### PR DESCRIPTION
Added Protected and Internal keywords to improve Monkey's encapsulation abilities.  These are mutually exclusive with Public and Private.

Protected = Only visible to the current module and subclasses in any other module.
Internal = Only visible to the current module and other modules in the same directory.

Internal could be improved if Monkey had better namespace support, so it's handy that Module is a reserved word!

Related forum topic:
http://www.monkey-x.com/Community/posts.php?topic=9581
