### PR TITLE
Mojo.Audio: Add GetChannelVolume(channel) and GetMusicVolume()

### DIFF
--- a/modules/mojo/audio.monkey
+++ b/modules/mojo/audio.monkey
@@ -15,6 +15,9 @@ Import audiodevice
 Import data
 
 Global device:AudioDevice
+'0-31 for sounds, 32 for music -> array length = 33
+Global channelVolumes:Float[] = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+
 
 Public
 
@@ -70,7 +73,15 @@ Function ChannelState( channel )
 End
 
 Function SetChannelVolume( channel,volume# )
+	'store as current volume (if valid)
+	If channel >= 0 And channel < 32 Then channelVolumes[channel] = volume
 	device.SetVolume channel,volume
+End
+
+Function GetChannelVolume:Float( channel:Int )
+	If channel >= 0 And channel < 32 Then Return channelVolumes[channel]
+	'a not existing channel is silent!
+	Return 0.0
 End
 
 Function SetChannelPan( channel,pan# )
@@ -102,7 +113,13 @@ Function MusicState()
 End
 
 Function SetMusicVolume( volume# )
+	'store as current volume
+	channelVolumes[32] = volume
 	device.SetMusicVolume volume
+End
+
+Function GetMusicVolume:Float()
+	Return channelVolumes[32]
 End
 
 #Endif


### PR DESCRIPTION
I do not know about that "If MOJO_VERSION_X ... Import mojox.audio", so
I am unsure what is done there (am only using the free monkey-version).

As there is no "MaxChannels"-value stored in the base audio.monkey, I
checked the available channels in GLFW and HTML5 and both had 33
channels (32 sfx and 1 music).
My implementation just hooks into the volume-setters and allows for
easier retrieval of current volumes.

Why? This is needed for situations in which multiple objects adjusts
volumes without knowing the other manipulators. It is similar to
GetAlpha() and SetAlpha().
