### PR TITLE
Fixed the GLFW+ANGLE target's MSVC template.

### DIFF
--- a/targets/glfw3_angle/template/msvc/MonkeyGame.vcxproj
+++ b/targets/glfw3_angle/template/msvc/MonkeyGame.vcxproj
@@ -80,11 +80,9 @@
       </Command>
     </CustomBuildStep>
     <PostBuildEvent>
-      <Command>copy ..\angle\bin\libEGL.dll $(TargetDir)
-copy ..\angle\bin\libGLESv2.dll $(TargetDir)
-copy ..\angle\bin\d3dcompiler_47.dll $(TargetDir)
-
-</Command>
+		  <Command>copy "..\angle\bin\libEGL.dll" "$(TargetDir)"</Command>
+	  	<Command>copy "..\angle\bin\libGLESv2.dll" "$(TargetDir)"</Command>
+	  	<Command>copy "..\angle\bin\d3dcompiler_47.dll" "$(TargetDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -112,10 +110,9 @@ copy ..\angle\bin\d3dcompiler_47.dll $(TargetDir)
       <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
     </Link>
     <PostBuildEvent>
-      <Command>copy ..\angle\bin\libEGL.dll $(TargetDir)
-copy ..\angle\bin\libGLESv2.dll $(TargetDir)
-copy ..\angle\bin\d3dcompiler_47.dll $(TargetDir)
-</Command>
+		  <Command>copy "..\angle\bin\libEGL.dll" "$(TargetDir)"</Command>
+		  <Command>copy "..\angle\bin\libGLESv2.dll" "$(TargetDir)"</Command>
+		  <Command>copy "..\angle\bin\d3dcompiler_47.dll" "$(TargetDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
This fixes the bug [reported here](http://www.monkey-x.com/Community/posts.php?topic=9897#106936), and discussed in [this thread](http://www.monkey-x.com/Community/posts.php?topic=9867&post=106927).

Basically, I just added quotes to the use(s) of the 'copy' command. This fixes path-ending problems; most notably, paths that have spaces.
