### PR TITLE
Allows inherited methods to satisfy interface requirements.

### DIFF
--- a/modules/trans/decl.monkey
+++ b/modules/trans/decl.monkey
@@ -1234,14 +1234,19 @@ Class ClassDecl Extends ScopeDecl
 		For Local iface:=Eachin implmentsAll
 			For Local decl:=Eachin iface.SemantedMethods()
 				Local found
-				For Local decl2:=Eachin SemantedMethods( decl.ident )
-					If decl.EqualsFunc( decl2 )
-						If decl2.munged
-							Err "Extern methods cannot be used to implement interface methods."
+				Local cdecl:=Self
+				While cdecl And Not found
+					For Local decl2:=Eachin cdecl.SemantedMethods( decl.ident )
+						If decl.EqualsFunc( decl2 )
+							If decl2.munged
+								Err "Extern methods cannot be used to implement interface methods."
+							Endif
+							found=True
 						Endif
-						found=True
-					Endif
-				Next
+					Next
+					cdecl=cdecl.superClass
+				Wend
+
 				If Not found
 					Err decl.ToString()+" must be implemented by class "+ToString()
 				Endif


### PR DESCRIPTION
Monkey does not allow inherited methods to be considered when checking if a class implements all required methods of an interface.  This change allows you to do that.

```
Interface Foo
    Method Hello:Void()
End

Class One
    Method Hello:Void()
        Print "test"
    End
End

Class Two Extends One Implements Foo
End

Function Main()
    Local f:Foo = New Two
    f.Hello()
End
```

Normally it would complain that Two does not implement Hello, even though it is inherited from One.
