### PR TITLE
Optimised GetDecl process for faster semanting across multiple files

### DIFF
--- a/modules/monkey/map.monkey
+++ b/modules/monkey/map.monkey
@@ -141,6 +141,14 @@ Class Map<K,V>
 		Return node
 	End
 	
+	Method Clone(from:Map<K, V>)
+		If Not from.root
+			root = Null
+			Return
+		EndIf
+		root = from.root.Copy(Null)
+	End
+	
 	'Deprecated - use Set
 	Method Insert:Bool( key:K,value:V )
 		Return Set( key,value )

--- a/modules/trans/decl.monkey
+++ b/modules/trans/decl.monkey
@@ -1273,9 +1273,10 @@ End
 Class ModuleDecl Extends ScopeDecl
 
 	Global master_uid:Int = 0
-
+	Global master_im_version:Int = 1
+	
 	Field uid:Int = 0
-	Field indirectMapsPrepped:Bool = False
+	Field indirectMapsVersion:Int = 0
 	Field indirectDeclMapPublicOnly:= New StringMap<SynonymList>
 	Field indirectDeclMapPublicPrivate:= New StringMap<SynonymList>
 	Field accessibleModuleScopesPublic:= New IntMap<ModuleDecl>
@@ -1379,7 +1380,7 @@ Class ModuleDecl Extends ScopeDecl
 		accessibleModuleScopesPublic = New IntMap<ModuleDecl>
 		accessibleModuleScopesPublicPrivate = New IntMap<ModuleDecl>
 		
-		indirectMapsPrepped = True
+		indirectMapsVersion = master_im_version
 		Local todo:= New List<ModuleDecl>
 		Local accListPublic:List<ModuleDecl> = New List<ModuleDecl>
 		Local accListPublicPrivate:List<ModuleDecl> = New List<ModuleDecl>
@@ -1504,7 +1505,7 @@ Class ModuleDecl Extends ScopeDecl
 			'Print "Done."
 		Else
 			If accessibleModuleScopesPublic.Contains(mdecl.uid)
-				If Not mdecl.indirectMapsPrepped
+				If mdecl.indirectMapsVersion < master_im_version
 					mdecl.BuildIndirectDeclMaps()
 				EndIf
 				'AC: The _env's own module scope is accessible from here.
@@ -1703,6 +1704,15 @@ Class ModuleDecl Extends ScopeDecl
 		attrs|=MODULE_SEMANTALL
 	End
 	
+	Method InsertDecl(decl:Decl)
+		Super.InsertDecl(decl)
+		master_im_version += 1
+	End
+
+	Method InsertDecls(decls:List<Decl>)
+		Super.InsertDecls(decls)
+		master_im_version += 1
+	End
 End
 
 Class AppDecl Extends ScopeDecl

--- a/modules/trans/decl.monkey
+++ b/modules/trans/decl.monkey
@@ -368,6 +368,9 @@ End
 
 Class ScopeDecl Extends Decl
 
+	Global GetDecl_Fail:Int
+	Global GetDecl_Success:Int
+
 Private
 
 	Field decls:=New List<Decl>
@@ -1484,13 +1487,14 @@ Class ModuleDecl Extends ScopeDecl
 	
 	Method GetDecl:Object(ident:String)
 	
-		If Not indirectMapsPrepped
+		If indirectMapsVersion < master_im_version
 			'Print "Building IDMs for " + Self.ident + "..."
 			BuildIndirectDeclMaps()
 			'Print "Done."
 		EndIf
 		
 		If Not _env
+			'AC: 'Slow' version probably quicker in this case as it's a smaller stringmap.
 			Return GetDecl_Slow(ident)
 		EndIf
 		


### PR DESCRIPTION
I discovered a significant speed-bump in the semanting process: every time a declaration made in file A is used in file B, the compiler rebuilds the entire import hierarchy of file B from scratch and searches every declaration map individually for conflicts.

In practice, this resulted in a near-linear relationship between number of files and semanting time for any given quantity of code.

This modified implementation improves performance by constructing the import hierarchy of file B just once, the first time a declaration is sought outside the file. From this it caches a single map of synonyms (lists of decls with the same identifier). 

Subsequently, seeking an external decl requires only a single string map lookup to obtain the appropriate synonym list. In correct code, only one synonym will pass the final accessibility test. If more than one pass, a duplicate identifier error is reported (via the old method, both for simplicity and to sanity-check the behaviour of the new system)

The upshot is a considerable reduction in semanting time on projects with large numbers of source files (from 45 seconds to under 3 seconds in our case).
