### PR TITLE
GLFW3 Window Closing Hotfix (OnClose)

### DIFF
--- a/targets/glfw3/modules/native/glfwgame.cpp
+++ b/targets/glfw3/modules/native/glfwgame.cpp
@@ -577,6 +577,9 @@ void BBGlfwGame::OnCursorPos( GLFWwindow *window,double x,double y ){
 void BBGlfwGame::OnWindowClose( GLFWwindow *window ){
 	_glfwGame->KeyEvent( BBGameEvent::KeyDown,0x1b0 );
 	_glfwGame->KeyEvent( BBGameEvent::KeyUp,0x1b0 );
+	
+	// Don't close the main window if the application wasn't closed at a higher level.
+	glfwSetWindowShouldClose(_glfwGame->_window, 0); // GL_FALSE
 }
 
 void BBGlfwGame::OnWindowSize( GLFWwindow *window,int width,int height ){

--- a/targets/glfw3_angle/modules/native/glfwgame.cpp
+++ b/targets/glfw3_angle/modules/native/glfwgame.cpp
@@ -580,6 +580,8 @@ void BBGlfwGame::OnCursorPos( GLFWwindow *window,double x,double y ){
 void BBGlfwGame::OnWindowClose( GLFWwindow *window ){
 	_glfwGame->KeyEvent( BBGameEvent::KeyDown,0x1b0 );
 	_glfwGame->KeyEvent( BBGameEvent::KeyUp,0x1b0 );
+	
+	glfwSetWindowShouldClose(_glfwGame->_window, 0); // GL_FALSE
 }
 
 void BBGlfwGame::OnWindowSize( GLFWwindow *window,int width,int height ){


### PR DESCRIPTION
**This fixes the bug discussed on the forums, [here](http://www.monkey-x.com/Community/posts.php?topic=10341#115565).**

Basically, GLFW3 (And ANGLE) will close a window by default, unless otherwise stopped. With this in mind, if you want to handle when 'EndApp' is called in Mojo, or more commonly, override the 'OnClose' method, the window would be closed without the developer giving the go-ahead. This fixes that behavior, albeit weirdly. This relies on 1-1 event handling for keyboard input, which I'm unsure about the behavior of.

This isn't the cleanest method, but it works for now. If you intend to clean this up more, don't bother merging, and please close this pull request. If you do take this into your own hands, I recommend looking further up the chain.
