### PR TITLE
Support stencil buffer flag in SetDeviceWindow()

### DIFF
--- a/modules/mojo/monkeydoc/app.monkeydoc
+++ b/modules/mojo/monkeydoc/app.monkeydoc
@@ -336,6 +336,7 @@ Calling this function does NOT result in your application's [[OnResize]] method 
 | 16		| Depth buffered		| glfw3
 | 32		| Single buffered		| glfw3
 | 64		| Use second monitor	| glfw3
+| 128		| Use stencil buffer	| glfw3
 
 Use [[DisplayModes]] for a list of valid fullscreen device width/heights.
 

--- a/targets/glfw3/modules/native/glfwgame.cpp
+++ b/targets/glfw3/modules/native/glfwgame.cpp
@@ -570,13 +570,14 @@ void BBGlfwGame::SetDeviceWindow( int width,int height,int flags ){
 	bool depthbuffer=(flags & 16);
 	bool doublebuffer=!(flags & 32);
 	bool secondmonitor=(flags & 64);
+	bool usestencil=(flags & 128);
 
 	glfwWindowHint( GLFW_RED_BITS,8 );
 	glfwWindowHint( GLFW_GREEN_BITS,8 );
 	glfwWindowHint( GLFW_BLUE_BITS,8 );
 	glfwWindowHint( GLFW_ALPHA_BITS,0 );
 	glfwWindowHint( GLFW_DEPTH_BITS,depthbuffer ? 32 : 0 );
-	glfwWindowHint( GLFW_STENCIL_BITS,0 );
+	glfwWindowHint( GLFW_STENCIL_BITS,usestencil ? 8 : 0 );
 	glfwWindowHint( GLFW_RESIZABLE,resizable );
 	glfwWindowHint( GLFW_DECORATED,decorated );
 	glfwWindowHint( GLFW_FLOATING,floating );


### PR DESCRIPTION
This code adds a flag to SetDeviceWindow() to hint an 8-bit stencil buffer depth, where the current default is 0.  On some systems tested, that default breaks glEnable(GL_STENCIL_TEST), including on one MacOS system (GPU unknown) and modern GeForce drivers for models 210 and gtx760.  This code allows the current default behavior to remain, while giving an option to fix the issue with the appropriate flag.
