### PR TITLE
Bug with Umlauts (HTML5 / Firefox)

### DIFF
--- a/targets/html5/modules/native/html5game.js
+++ b/targets/html5/modules/native/html5game.js
@@ -424,7 +424,7 @@ BBHtml5Game.prototype.Run=function(){
 		game.KeyEvent( BBGameEvent.KeyDown,e.keyCode );
 		var chr=keyToChar( e.keyCode );
 		if( chr ) game.KeyEvent( BBGameEvent.KeyChar,chr );
-		if( e.keyCode<48 || (e.keyCode>111 && e.keyCode<122) ) eatEvent( e );
+		if( (e.keyCode>0 && e.keyCode<48) || (e.keyCode>111 && e.keyCode<122) ) eatEvent( e );
 	}
 
 	canvas.onkeyup=function( e ){


### PR DESCRIPTION
On FireFox keyevents with umlauts are fireing with keycode '0'. Those events shouldn't get eaten by Monkey or we won't receive those events within monkey (KeyDown works - GetChar doesn't work)
