### PR TITLE
Bugfix: Samsung Galaxy S3 - Android Browser - Databuffer Boundary Bugfix

### DIFF
--- a/modules/brl/native/databuffer.js
+++ b/modules/brl/native/databuffer.js
@@ -11,8 +11,21 @@ BBDataBuffer.tints=new Int32Array( BBDataBuffer.tbuf );
 BBDataBuffer.tfloats=new Float32Array( BBDataBuffer.tbuf );
 
 BBDataBuffer.prototype._Init=function( buffer ){
+  
+  this.length=buffer.byteLength;
+  
+  if (buffer.byteLength != Math.ceil(buffer.byteLength / 4) * 4)
+  {
+    var new_buffer = new ArrayBuffer(Math.ceil(buffer.byteLength / 4) * 4);
+    var src = new Int8Array(buffer);
+    var dst = new Int8Array(new_buffer);
+    for (var i = 0; i < this.length; i++) {
+      dst[i] = src[i];
+    }
+    buffer = new_buffer;    
+  }
+
 	this.arrayBuffer=buffer;
-	this.length=buffer.byteLength;
 	this.bytes=new Int8Array( buffer );	
 	this.shorts=new Int16Array( buffer,0,this.length/2 );	
 	this.ints=new Int32Array( buffer,0,this.length/4 );	


### PR DESCRIPTION
The Android Browser in my Samsung Galaxy S3 (Android 4.4.2) does have a
problem that I haven't encountered in other Browsers:

Creating a buffer view with an buffer that has a size that isn't
a multiple of the base type creates an Exception:

ArrayBuffer length minus the byteOffset is not a multiple of the element size

This happened to me in a game where I'm loading a Binary File. Of course
it is possible that the size of this Binary File isn't a multiple of 4.

Now when Monkey tries to load in the File into a DataBuffer object the
above-mentioned Exception is thrown.

I've created a workaround in this pull request because I weren't able
to come up with a cleaner solution:

If the length of the buffer isn't a multiple of 4, I copy/resize the
buffer to be a multiple of 4 in length.

But I keep the original length property so that the seeking logic
remains the same.
